### PR TITLE
Ignore private underscore-prefixed Cursor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,6 +207,9 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
+# Repo-local Cursor rules that should remain untracked
+.cursor/rules/github-mcp-local.mdc
+
 # Marimo
 marimo/_static/
 marimo/_lsp/

--- a/.gitignore
+++ b/.gitignore
@@ -207,8 +207,9 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
-# Repo-local Cursor rules that should remain untracked
-.cursor/rules/github-mcp-local.mdc
+# Repo-local Cursor files under .cursor/ starting with underscore that should remain untracked
+.cursor/_*
+.cursor/**/_*
 
 # Marimo
 marimo/_static/


### PR DESCRIPTION
## Summary
- Update `.gitignore` to ignore any files or directories under `.cursor/` whose names start with an underscore.
- This allows keeping repo-specific, private Cursor configs (like local MCP rules) untracked while still using shared `.cursor` config in version control.

## Test plan
- Confirm `.gitignore` contains the new patterns:
  - `.cursor/_*`
  - `.cursor/**/_*`
- Create a test file such as `.cursor/_local-test.mdc` or `.cursor/rules/_private-rule.mdc` and verify `git status` remains clean.
